### PR TITLE
Fixed createPaymentRequest

### DIFF
--- a/src/accessToken.js
+++ b/src/accessToken.js
@@ -15,7 +15,7 @@ export class AccessToken {
     scope: string
 
     constructor(input: AccessTokenInput) {
-        this.tokenType = input.token_type,
+        this.tokenType = input.token_type;
         this.token = input.access_token;
         this.expiresIn = input.expires_in;
         this.expiry = new Date(Date.now() + input.expires_in * 60);

--- a/src/client.js
+++ b/src/client.js
@@ -34,8 +34,8 @@ export class TikkieClient {
 
     createPaymentRequest = (platformToken: string, userToken: string, bankAccountToken: string, data: Object) =>
         this.config.postRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/bankaccounts/${bankAccountToken}/paymentrequests`, data)
-    getPaymentRequests = (platformToken: string, userToken: string) =>
-        this.config.getRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/paymentrequests`)
+    getPaymentRequests = (platformToken: string, userToken: string, queryParams: object) =>
+        this.config.getRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/paymentrequests`, queryParams)
     getPaymentRequest = (platformToken: string, userToken: string, paymentRequestToken: string) =>
         this.config.getRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/paymentrequests/${paymentRequestToken}`)
 };

--- a/src/client.js
+++ b/src/client.js
@@ -33,7 +33,7 @@ export class TikkieClient {
     getUsers = (platformToken: string) => this.config.getRequest(`/v1/tikkie/platforms/${platformToken}/users`)
 
     createPaymentRequest = (platformToken: string, userToken: string, bankAccountToken: string, data: Object) =>
-        this.config.postRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/banksaccounts/${bankAccountToken}/paymentrequests`, data)
+        this.config.postRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/bankaccounts/${bankAccountToken}/paymentrequests`, data)
     getPaymentRequests = (platformToken: string, userToken: string) =>
         this.config.getRequest(`/v1/tikkie/platforms/${platformToken}/users/${userToken}/paymentrequests`)
     getPaymentRequest = (platformToken: string, userToken: string, paymentRequestToken: string) =>

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,9 @@
 // @flow
 
 import fs from 'fs';
-import {URLSearchParams} from 'url';
+import {URLSearchParams, format} from 'url';
 import jwt from 'jsonwebtoken';
+
 
 import {AccessToken} from './accessToken';
 import {TikkieErrorCollection} from './error';
@@ -98,14 +99,17 @@ export class TikkieConfig {
 
             const headers: Headers = this.createHeaders();
             headers.append('Authorization', `Bearer ${token}`);
-            if (data) {
+            if (method === 'POST' && data) {
                 headers.append('Content-Type', 'application/json');
+            }
+            if (method === 'GET' && data) {
+                endpoint += format({query: data});
             }
 
             const response: Response = await fetch(`${this.apiUrl}${endpoint}`, {
                 method,
                 headers,
-                body: data ? JSON.stringify(data) : undefined
+                body: (method === 'POST' && data) ? JSON.stringify(data) : undefined
             });
             const result: Object = await response.json();
 
@@ -119,6 +123,6 @@ export class TikkieConfig {
         }
     }
 
-    getRequest = (endpoint: string): Promise<Object> => this.request('GET', endpoint)
+    getRequest = (endpoint: string, queryParams: object = {}): Promise<Object> => this.request('GET', endpoint, queryParams)
     postRequest = (endpoint: string, data: Object = {}): Promise<Object> => this.request('POST', endpoint, data)
 };


### PR DESCRIPTION
Due to a typ0 in the (current?) spec of the URL the createPaymentRequest call will fail.

I've also updated the GET PaymentRequests to allow for accepting queryParams as this is required for atleast including `offset` and `limit`.