### PR TITLE
fix import issue with jsonwebtoken when converting typescript to javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ logs/
 
 Thumbs.db
 .DS_Store
+
+.idea

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import {URLSearchParams, format} from 'url';
-import jwt from 'jsonwebtoken';
+import * as jwt from 'jsonwebtoken';
 
 import {AccessToken} from './accessToken';
 import {TikkieErrorCollection} from './error';


### PR DESCRIPTION
Because we rewrote this library to TypeScript there was an issue with the import of `jsonwebtoken` this request solved that issue